### PR TITLE
Finish propagating SHARED_VERSION_INFO

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -5,3 +5,4 @@ libGDSII_la_SOURCES = 		\
  libGDSII.cc			\
  Flatten.cc 			\
  ReadGDSIIFile.cc
+libGDSII_la_LDFLAGS = -version-info @SHARED_VERSION_INFO@


### PR DESCRIPTION
It's set in configure.ac (taking for granted that release workflow involves setting it properly per docs) and propagated into the generated makefiles, but it needs to be passed explicitly when building the shared library.

The existing 0:0:0 has the same effect as not passing it at all (setting ABI version details such as SONAME in the binary library) so there's no change on the current state or packaging disruption due to this change as long as it's done before you make any API changes.